### PR TITLE
GetPlayerNameWorldHistories() IPC

### DIFF
--- a/PlayerTrack.Domain/Services/PlayerServices/PlayerChangeService.cs
+++ b/PlayerTrack.Domain/Services/PlayerServices/PlayerChangeService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Dalamud.DrunkenToad.Core;
 using PlayerTrack.Infrastructure;
@@ -91,14 +92,14 @@ public class PlayerChangeService
         return worldNames.Any() ? string.Join(", ", worldNames) : string.Empty;
     }
 
-    public static PlayerNameWorldHistory[] GetPlayerNameWorldHistories(int[] playerIds)
+    public static List<PlayerNameWorldHistory> GetPlayerNameWorldHistories(IEnumerable<int> playerIds)
     {
-        DalamudContext.PluginLog.Verbose($"Entering PlayerChangeService.GetPlayersNameWorldHistory()");
-        var nameWorldHistories = RepositoryContext.PlayerNameWorldHistoryRepository.GetPlayerNameWorldHistories(playerIds);
+        DalamudContext.PluginLog.Verbose($"Entering PlayerChangeService.GetPlayerNameWorldHistories()");
+        var nameWorldHistories = RepositoryContext.PlayerNameWorldHistoryRepository.GetPlayerNameWorldHistories(playerIds.ToArray());
         if (nameWorldHistories == null)
         {
-            return new PlayerNameWorldHistory[] { };
+            return new List<PlayerNameWorldHistory> { };
         }
-        return nameWorldHistories;
+        return nameWorldHistories.ToList();
     }
 }

--- a/PlayerTrack.Domain/Services/PlayerServices/PlayerChangeService.cs
+++ b/PlayerTrack.Domain/Services/PlayerServices/PlayerChangeService.cs
@@ -90,4 +90,15 @@ public class PlayerChangeService
 
         return worldNames.Any() ? string.Join(", ", worldNames) : string.Empty;
     }
+
+    public static PlayerNameWorldHistory[] GetPlayerNameWorldHistories(int[] playerIds)
+    {
+        DalamudContext.PluginLog.Verbose($"Entering PlayerChangeService.GetPlayersNameWorldHistory()");
+        var nameWorldHistories = RepositoryContext.PlayerNameWorldHistoryRepository.GetPlayerNameWorldHistories(playerIds);
+        if (nameWorldHistories == null)
+        {
+            return new PlayerNameWorldHistory[] { };
+        }
+        return nameWorldHistories;
+    }
 }

--- a/PlayerTrack.Infrastructure/Repositories/PlayerNameWorldHistoryRepository.cs
+++ b/PlayerTrack.Infrastructure/Repositories/PlayerNameWorldHistoryRepository.cs
@@ -80,9 +80,9 @@ public class PlayerNameWorldHistoryRepository : BaseRepository
         }
     }
 
-    public PlayerNameWorldHistory[]? GetPlayerNameWorldHistories(int[] playerIds) 
+    public IEnumerable<PlayerNameWorldHistory>? GetPlayerNameWorldHistories(int[] playerIds) 
     {
-        DalamudContext.PluginLog.Verbose($"Entering PlayerNameWorldHistoryRepository.BulkGetNameWorldHistory()");
+        DalamudContext.PluginLog.Verbose($"Entering PlayerNameWorldHistoryRepository.GetPlayerNameWorldHistories()");
         try 
         {
             string sql = "SELECT * FROM player_name_world_histories ";
@@ -93,17 +93,7 @@ public class PlayerNameWorldHistoryRepository : BaseRepository
                 whereClause += $" OR player_id = {playerIds[i]}";
             }
             sql += whereClause;
-            DalamudContext.PluginLog.Debug(sql);
-
-            return this.Connection.Query<PlayerNameWorldHistoryDTO>(sql).Select(x => new PlayerNameWorldHistory()
-            {
-                PlayerId = x.player_id,
-                PlayerName = x.player_name,
-                WorldId = x.world_id,
-                Created = x.created,
-                Updated = x.updated,
-                IsMigrated = x.is_migrated
-            }).ToArray();
+            return this.Connection.Query<PlayerNameWorldHistoryDTO>(sql).Select(x => Mapper.Map<PlayerNameWorldHistory>(x));
         }
         catch (Exception ex) 
         {

--- a/PlayerTrack.Infrastructure/Repositories/PlayerNameWorldHistoryRepository.cs
+++ b/PlayerTrack.Infrastructure/Repositories/PlayerNameWorldHistoryRepository.cs
@@ -80,6 +80,38 @@ public class PlayerNameWorldHistoryRepository : BaseRepository
         }
     }
 
+    public PlayerNameWorldHistory[]? GetPlayerNameWorldHistories(int[] playerIds) 
+    {
+        DalamudContext.PluginLog.Verbose($"Entering PlayerNameWorldHistoryRepository.BulkGetNameWorldHistory()");
+        try 
+        {
+            string sql = "SELECT * FROM player_name_world_histories ";
+            string whereClause = $"WHERE player_id = {playerIds[0]}";
+
+            for(int i = 1; i < playerIds.Length; i++)
+            {
+                whereClause += $" OR player_id = {playerIds[i]}";
+            }
+            sql += whereClause;
+            DalamudContext.PluginLog.Debug(sql);
+
+            return this.Connection.Query<PlayerNameWorldHistoryDTO>(sql).Select(x => new PlayerNameWorldHistory()
+            {
+                PlayerId = x.player_id,
+                PlayerName = x.player_name,
+                WorldId = x.world_id,
+                Created = x.created,
+                Updated = x.updated,
+                IsMigrated = x.is_migrated
+            }).ToArray();
+        }
+        catch (Exception ex) 
+        {
+            DalamudContext.PluginLog.Error(ex, $"Failed to get bulk player name world history.");
+            return null;
+        }
+    }
+
     public bool DeleteNameWorldHistory(int playerId)
     {
         DalamudContext.PluginLog.Verbose($"Entering PlayerNameWorldHistoryRepository.DeleteNameWorldHistory(): {playerId}");

--- a/PlayerTrack.Plugin/API/IPlayerTrackAPI.cs
+++ b/PlayerTrack.Plugin/API/IPlayerTrackAPI.cs
@@ -27,9 +27,9 @@ public interface IPlayerTrackAPI
     public string GetPlayerNotes(string name, uint worldId);
 
     /// <summary>
-    /// Returns a set of all known unique names/worlds combinations for a list of players
+    /// Returns the player names/world history for a list of players
     /// </summary>
     /// <param name="players">tuple array of (player name, world id)</param>
-    /// <returns>tuple array of current (player name, world id) and an array of known unique previous (player name, world id) combinations.</returns>
-    public ((string, uint), (string, uint)[])[] GetUniquePlayerNameWorldHistories((string, uint)[] players);
+    /// <returns>tuple array of current (player name, world id) and an array of (player name, world id) name/world changes.</returns>
+    public ((string, uint), (string, uint)[])[] GetPlayerNameWorldHistories((string, uint)[] players);
 }

--- a/PlayerTrack.Plugin/API/IPlayerTrackAPI.cs
+++ b/PlayerTrack.Plugin/API/IPlayerTrackAPI.cs
@@ -19,14 +19,6 @@ public interface IPlayerTrackAPI
     public string GetPlayerCurrentNameWorld(string name, uint worldId);
 
     /// <summary>
-    /// Gets the player's Lodestone Id
-    /// </summary>
-    /// <param name="name">full player name at point in time.</param>
-    /// <param name="worldId">player home world id at point in time.</param>
-    /// <returns>Lodestone Id</returns>
-    public uint GetPlayerLodestoneId(string name, uint worldId);
-
-    /// <summary>
     /// Get notes for player.
     /// </summary>
     /// <param name="name">player's full name.</param>
@@ -35,24 +27,9 @@ public interface IPlayerTrackAPI
     public string GetPlayerNotes(string name, uint worldId);
 
     /// <summary>
-    /// Gets the player's previous names
+    /// Returns a set of all known unique names/worlds combinations for a list of players
     /// </summary>
-    /// <param name="name">full player name at point in time.</param>
-    /// <param name="worldId">player home world id at point in time.</param>
-    /// <returns>Lodestone Id</returns>
-    public string[] GetPlayerPreviousNames(string name, uint worldId);
-    /// <summary>
-    /// Gets the player's previous names
-    /// </summary>
-    /// <param name="name">full player name at point in time.</param>
-    /// <param name="worldId">player home world id at point in time.</param>
-    /// <returns>Previous Names</returns>
-    public string[] GetPlayerPreviousWorlds(string name, uint worldId);
-
-    /// <summary>
-    /// Returns a set of all known previous names and worlds for a list of players
-    /// </summary>
-    /// <param name="players">tuple array of player names and world Ids</param>
-    /// <returns>tuple array of current player name+world id and lists of previous names and worlds</returns>
-    public ((string, uint), string[], uint[])[] GetPlayersPreviousNamesWorlds((string, uint)[] players);
+    /// <param name="players">tuple array of (player name, world id)</param>
+    /// <returns>tuple array of current (player name, world id) and an array of known unique previous (player name, world id) combinations.</returns>
+    public ((string, uint), (string, uint)[])[] GetUniquePlayerNameWorldHistories((string, uint)[] players);
 }

--- a/PlayerTrack.Plugin/API/IPlayerTrackAPI.cs
+++ b/PlayerTrack.Plugin/API/IPlayerTrackAPI.cs
@@ -19,10 +19,40 @@ public interface IPlayerTrackAPI
     public string GetPlayerCurrentNameWorld(string name, uint worldId);
 
     /// <summary>
+    /// Gets the player's Lodestone Id
+    /// </summary>
+    /// <param name="name">full player name at point in time.</param>
+    /// <param name="worldId">player home world id at point in time.</param>
+    /// <returns>Lodestone Id</returns>
+    public uint GetPlayerLodestoneId(string name, uint worldId);
+
+    /// <summary>
     /// Get notes for player.
     /// </summary>
     /// <param name="name">player's full name.</param>
     /// <param name="worldId">player home world id.</param>
     /// <returns>notes.</returns>
     public string GetPlayerNotes(string name, uint worldId);
+
+    /// <summary>
+    /// Gets the player's previous names
+    /// </summary>
+    /// <param name="name">full player name at point in time.</param>
+    /// <param name="worldId">player home world id at point in time.</param>
+    /// <returns>Lodestone Id</returns>
+    public string[] GetPlayerPreviousNames(string name, uint worldId);
+    /// <summary>
+    /// Gets the player's previous names
+    /// </summary>
+    /// <param name="name">full player name at point in time.</param>
+    /// <param name="worldId">player home world id at point in time.</param>
+    /// <returns>Previous Names</returns>
+    public string[] GetPlayerPreviousWorlds(string name, uint worldId);
+
+    /// <summary>
+    /// Returns a set of all known previous names and worlds for a list of players
+    /// </summary>
+    /// <param name="players">tuple array of player names and world Ids</param>
+    /// <returns>tuple array of current player name+world id and lists of previous names and worlds</returns>
+    public ((string, uint), string[], uint[])[] GetPlayersPreviousNamesWorlds((string, uint)[] players);
 }

--- a/PlayerTrack.Plugin/API/PlayerTrackAPI.cs
+++ b/PlayerTrack.Plugin/API/PlayerTrackAPI.cs
@@ -4,6 +4,12 @@ using PlayerTrack.Domain;
 namespace PlayerTrack.API;
 
 using Dalamud.DrunkenToad.Core;
+using Dalamud.Utility;
+using PlayerTrack.Infrastructure;
+using PlayerTrack.Models;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
 
 /// <inheritdoc cref="IPlayerTrackAPI" />
 public class PlayerTrackAPI : IPlayerTrackAPI
@@ -34,6 +40,19 @@ public class PlayerTrackAPI : IPlayerTrackAPI
     }
 
     /// <inheritdoc />
+    public uint GetPlayerLodestoneId(string name, uint worldId) {
+        DalamudContext.PluginLog.Verbose($"Entering PlayerTrackAPI.GetPlayerLodestoneId({name}, {worldId})");
+        this.CheckInitialized();
+        var player = ServiceContext.PlayerDataService.GetPlayer(name, worldId);
+        if (player == null) {
+            DalamudContext.PluginLog.Warning("Player not found");
+            return 0;
+        }
+
+        return player.LodestoneId;
+    }
+
+    /// <inheritdoc />
     public string GetPlayerNotes(string name, uint worldId)
     {
         DalamudContext.PluginLog.Verbose($"Entering PlayerTrackAPI.GetPlayerNotes({name}, {worldId})");
@@ -46,6 +65,85 @@ public class PlayerTrackAPI : IPlayerTrackAPI
         }
 
         return player.Notes;
+    }
+
+    /// <inheritdoc />
+    public string[] GetPlayerPreviousNames(string name, uint worldId) 
+    {
+        DalamudContext.PluginLog.Verbose($"Entering PlayerTrackAPI.GetPlayerPreviousNames({name}, {worldId})");
+        this.CheckInitialized();
+        var player = ServiceContext.PlayerDataService.GetPlayer(name, worldId);
+        if (player == null) 
+        {
+            //DalamudContext.PluginLog.Warning("Player not found");
+            return new string[] { };
+        }
+        var pNames = PlayerChangeService.GetPreviousNames(player.Id, player.Name);
+        DalamudContext.PluginLog.Debug($"Previous names: {pNames}");
+        return pNames.Split(",");
+    }
+
+    /// <inheritdoc />
+    public string[] GetPlayerPreviousWorlds(string name, uint worldId) 
+    {
+        DalamudContext.PluginLog.Verbose($"Entering PlayerTrackAPI.GetPlayerPreviousWorlds({name}, {worldId})");
+        this.CheckInitialized();
+        var player = ServiceContext.PlayerDataService.GetPlayer(name, worldId);
+        if (player == null) 
+        {
+            //DalamudContext.PluginLog.Warning("Player not found");
+            return new string[] { };
+        }
+
+        var pWorlds = PlayerChangeService.GetPreviousWorlds(player.Id, player.Name);
+        DalamudContext.PluginLog.Debug($"Previous worlds: {pWorlds}");
+        return pWorlds.Split(",");
+    }
+
+    public ((string, uint), string[], uint[])[] GetPlayersPreviousNamesWorlds((string, uint)[] players) 
+    {
+        DalamudContext.PluginLog.Verbose($"Entering PlayerTrackAPI.GetPlayersPreviousNamesWorlds(count: {players.Length})");
+        this.CheckInitialized();
+        List<Player> playerObjList = new();
+        playerObjList = ServiceContext.PlayerDataService.GetAllPlayers().Where(x => players.ToList().Contains((x.Name, x.WorldId))).ToList();
+
+        //foreach(var player in players)
+        //{
+        //    var playerObj = ServiceContext.PlayerDataService.GetPlayer(player.Item1, player.Item2);
+        //    if(playerObj != null)
+        //    {
+        //        playerObjList.Add(playerObj);
+        //    }
+        //}
+        var playerHistories = PlayerChangeService.GetPlayerNameWorldHistories(playerObjList.Select(x => x.Id).ToArray());
+
+        if (playerHistories == null) 
+        {
+            DalamudContext.PluginLog.Warning("No player name/world history found.");
+            return new ((string, uint), string[], uint[])[] { };
+        }
+
+        Dictionary<int, (List<string>, List<uint>)> combinedResults = new();
+        foreach(var playerHistory in playerHistories)
+        {
+            var player = playerObjList.Where(x => x.Id == playerHistory.PlayerId).FirstOrDefault();
+            if (!combinedResults.ContainsKey(playerHistory.PlayerId))
+            {
+                combinedResults.Add(playerHistory.PlayerId, (new(), new()));
+            }
+            if (!playerHistory.PlayerName.IsNullOrEmpty() && !combinedResults[playerHistory.PlayerId].Item1.Contains(playerHistory.PlayerName) && player?.Name != playerHistory.PlayerName)
+            {
+                combinedResults[playerHistory.PlayerId].Item1.Add(playerHistory.PlayerName);
+            }
+            if (playerHistory.WorldId != 0 && !combinedResults[playerHistory.PlayerId].Item2.Contains(playerHistory.WorldId) && player?.WorldId != playerHistory.WorldId)
+            {
+                combinedResults[playerHistory.PlayerId].Item2.Add(playerHistory.WorldId);
+            }
+        }
+        //return combinedResults.Select(x => (playerObjList.Where(y => y.Id == x.Key)
+        //.Select(z => $"{z.Name} {z.WorldId}").First(), x.Value.Item1.ToArray(), x.Value.Item2.ToArray())).ToArray();
+        return combinedResults.Select(x => (playerObjList.Where(y => y.Id == x.Key)
+        .Select(y => (y.Name, y.WorldId)).First(), x.Value.Item1.ToArray(), x.Value.Item2.ToArray())).ToArray();
     }
 
     private void CheckInitialized()

--- a/PlayerTrack.Plugin/API/PlayerTrackAPI.cs
+++ b/PlayerTrack.Plugin/API/PlayerTrackAPI.cs
@@ -52,9 +52,9 @@ public class PlayerTrackAPI : IPlayerTrackAPI
     }
 
     /// <inheritdoc />
-    public ((string, uint), (string, uint)[])[] GetUniquePlayerNameWorldHistories((string, uint)[] players) 
+    public ((string, uint), (string, uint)[])[] GetPlayerNameWorldHistories((string, uint)[] players) 
     {
-        DalamudContext.PluginLog.Verbose($"Entering PlayerTrackAPI.GetUniquePlayerNameWorldHistories(count: {players.Length})");
+        DalamudContext.PluginLog.Verbose($"Entering PlayerTrackAPI.GetPlayerNameWorldHistories() (count: {players.Length})");
         this.CheckInitialized();
         List<Player> playerObjList = new();
         playerObjList = ServiceContext.PlayerDataService.GetAllPlayers().Where(x => players.ToList().Contains((x.Name, x.WorldId))).ToList();
@@ -73,13 +73,7 @@ public class PlayerTrackAPI : IPlayerTrackAPI
             {
                 combinedResults.Add(playerHistory.PlayerId, new());
             }
-            //only add non-migrated, non-current and unique records
-            if(!playerHistory.IsMigrated
-                && !(player?.Name == playerHistory.PlayerName && player?.WorldId == playerHistory.WorldId)
-                && !combinedResults[playerHistory.PlayerId].Any(x => x.Item1 == playerHistory.PlayerName && x.Item2 == playerHistory.WorldId))
-            {
-                combinedResults[playerHistory.PlayerId].Add((playerHistory.PlayerName, playerHistory.WorldId));
-            }
+            combinedResults[playerHistory.PlayerId].Add((playerHistory.PlayerName, playerHistory.WorldId));
         }
         return combinedResults.Where(x => x.Value.Any()).Select(x => (
         playerObjList.Where(y => y.Id == x.Key).Select(y => (y.Name, y.WorldId)).First(),

--- a/PlayerTrack.Plugin/API/PlayerTrackProvider.cs
+++ b/PlayerTrack.Plugin/API/PlayerTrackProvider.cs
@@ -23,28 +23,14 @@ public class PlayerTrackProvider
     public const string LabelProviderGetPlayerCurrentNameWorld = "PlayerTrack.GetPlayerCurrentNameWorld";
 
     /// <summary>
-    /// GetPlayerLodestoneId.
-    /// </summary>
-    public const string LabelProviderGetPlayerLodestoneId = "PlayerTrack.GetPlayerLodestoneId";
-
-    /// <summary>
     /// GetPlayerNotes.
     /// </summary>
     public const string LabelProviderGetPlayerNotes = "PlayerTrack.GetPlayerNotes";
 
     /// <summary>
-    /// GetPlayerPreviousNames.
+    /// GetUniquePlayerNameWorldHistories.
     /// </summary>
-    public const string LabelProviderGetPlayerPreviousNames = "PlayerTrack.GetPlayerPreviousNames";
-
-    /// <summary>
-    /// GetPlayerPreviousWorlds.
-    /// </summary>
-    public const string LabelProviderGetPlayerPreviousWorlds = "PlayerTrack.GetPlayerPreviousWorlds";
-    /// <summary>
-    /// GetPlayerPreviousWorlds.
-    /// </summary>
-    public const string LabelProviderGetPlayersPreviousNamesWorlds = "PlayerTrack.GetPlayersPreviousNamesWorlds";
+    public const string LabelProviderGetUniquePlayerNameWorldHistories = "PlayerTrack.GetUniquePlayerNameWorldHistories";
 
     /// <summary>
     /// API.
@@ -62,29 +48,14 @@ public class PlayerTrackProvider
     public readonly ICallGateProvider<string, uint, string>? ProviderGetPlayerCurrentNameWorld;
 
     /// <summary>
-    /// GetPlayerLodestoneId.
-    /// </summary>
-    public readonly ICallGateProvider<string, uint, uint>? ProviderGetPlayerLodestoneId;
-
-    /// <summary>
     /// GetPlayerNotes.
     /// </summary>
     public readonly ICallGateProvider<string, uint, string>? ProviderGetPlayerNotes;
 
     /// <summary>
-    /// GetPlayerPreviousNames.
+    /// GetUniquePlayerNameWorldHistories.
     /// </summary>
-    public readonly ICallGateProvider<string, uint, string[]>? ProviderGetPlayerPreviousNames;
-
-    /// <summary>
-    /// GetPlayerPreviousWorlds.
-    /// </summary>
-    public readonly ICallGateProvider<string, uint, string[]>? ProviderGetPlayerPreviousWorlds;
-
-    /// <summary>
-    /// GetPlayersPreviousNamesWorlds.
-    /// </summary>
-    public readonly ICallGateProvider<(string, uint)[], ((string, uint), string[], uint[])[]>? ProviderGetPlayersPreviousNamesWorlds;
+    public readonly ICallGateProvider<(string, uint)[], ((string, uint), (string, uint)[])[]>? GetUniquePlayerNameWorldHistories;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PlayerTrackProvider"/> class.
@@ -117,17 +88,6 @@ public class PlayerTrackProvider
             DalamudContext.PluginLog.Error($"Error registering IPC provider for {LabelProviderGetPlayerCurrentNameWorld}:\n{e}");
         }
 
-        try 
-        {
-            this.ProviderGetPlayerLodestoneId =
-                pluginInterface.GetIpcProvider<string, uint, uint>(LabelProviderGetPlayerLodestoneId);
-            this.ProviderGetPlayerLodestoneId.RegisterFunc(api.GetPlayerLodestoneId);
-        }
-        catch (Exception e) 
-        {
-            DalamudContext.PluginLog.Error($"Error registering IPC provider for {LabelProviderGetPlayerLodestoneId}:\n{e}");
-        }
-
         try
         {
             this.ProviderGetPlayerNotes =
@@ -139,37 +99,15 @@ public class PlayerTrackProvider
             DalamudContext.PluginLog.Error($"Error registering IPC provider for {LabelProviderGetPlayerNotes}:\n{e}");
         }
 
-        try 
-        {
-            this.ProviderGetPlayerPreviousNames =
-                pluginInterface.GetIpcProvider<string, uint, string[]>(LabelProviderGetPlayerPreviousNames);
-            this.ProviderGetPlayerPreviousNames.RegisterFunc(api.GetPlayerPreviousNames);
-        }
-        catch (Exception e) 
-        {
-            DalamudContext.PluginLog.Error($"Error registering IPC provider for {LabelProviderGetPlayerPreviousNames}:\n{e}");
-        }
-
-        try 
-        {
-            this.ProviderGetPlayerPreviousWorlds =
-                pluginInterface.GetIpcProvider<string, uint, string[]>(LabelProviderGetPlayerPreviousWorlds);
-            this.ProviderGetPlayerPreviousWorlds.RegisterFunc(api.GetPlayerPreviousWorlds);
-        }
-        catch (Exception e) 
-        {
-            DalamudContext.PluginLog.Error($"Error registering IPC provider for {LabelProviderGetPlayerPreviousWorlds}:\n{e}");
-        }
-
         try
         {
-            this.ProviderGetPlayersPreviousNamesWorlds =
-                pluginInterface.GetIpcProvider<(string, uint)[], ((string, uint), string[], uint[])[]>(LabelProviderGetPlayersPreviousNamesWorlds);
-            this.ProviderGetPlayersPreviousNamesWorlds.RegisterFunc(api.GetPlayersPreviousNamesWorlds);
+            this.GetUniquePlayerNameWorldHistories =
+                pluginInterface.GetIpcProvider<(string, uint)[], ((string, uint), (string, uint)[])[]>(LabelProviderGetUniquePlayerNameWorldHistories);
+            this.GetUniquePlayerNameWorldHistories.RegisterFunc(api.GetUniquePlayerNameWorldHistories);
         }
         catch (Exception e)
         {
-            DalamudContext.PluginLog.Error($"Error registering IPC provider for {LabelProviderGetPlayersPreviousNamesWorlds}:\n{e}");
+            DalamudContext.PluginLog.Error($"Error registering IPC provider for {LabelProviderGetUniquePlayerNameWorldHistories}:\n{e}");
         }
     }
 
@@ -182,8 +120,6 @@ public class PlayerTrackProvider
         this.ProviderAPIVersion?.UnregisterFunc();
         this.ProviderGetPlayerCurrentNameWorld?.UnregisterFunc();
         this.ProviderGetPlayerNotes?.UnregisterFunc();
-        this.ProviderGetPlayerPreviousNames?.UnregisterFunc();
-        this.ProviderGetPlayerPreviousWorlds?.UnregisterFunc();
-        this.ProviderGetPlayersPreviousNamesWorlds?.UnregisterFunc();
+        this.GetUniquePlayerNameWorldHistories?.UnregisterFunc();
     }
 }

--- a/PlayerTrack.Plugin/API/PlayerTrackProvider.cs
+++ b/PlayerTrack.Plugin/API/PlayerTrackProvider.cs
@@ -21,11 +21,30 @@ public class PlayerTrackProvider
     /// GetPlayerCurrentNameWorld.
     /// </summary>
     public const string LabelProviderGetPlayerCurrentNameWorld = "PlayerTrack.GetPlayerCurrentNameWorld";
-    
+
+    /// <summary>
+    /// GetPlayerLodestoneId.
+    /// </summary>
+    public const string LabelProviderGetPlayerLodestoneId = "PlayerTrack.GetPlayerLodestoneId";
+
     /// <summary>
     /// GetPlayerNotes.
     /// </summary>
     public const string LabelProviderGetPlayerNotes = "PlayerTrack.GetPlayerNotes";
+
+    /// <summary>
+    /// GetPlayerPreviousNames.
+    /// </summary>
+    public const string LabelProviderGetPlayerPreviousNames = "PlayerTrack.GetPlayerPreviousNames";
+
+    /// <summary>
+    /// GetPlayerPreviousWorlds.
+    /// </summary>
+    public const string LabelProviderGetPlayerPreviousWorlds = "PlayerTrack.GetPlayerPreviousWorlds";
+    /// <summary>
+    /// GetPlayerPreviousWorlds.
+    /// </summary>
+    public const string LabelProviderGetPlayersPreviousNamesWorlds = "PlayerTrack.GetPlayersPreviousNamesWorlds";
 
     /// <summary>
     /// API.
@@ -41,11 +60,31 @@ public class PlayerTrackProvider
     /// GetPlayerCurrentNameWorld.
     /// </summary>
     public readonly ICallGateProvider<string, uint, string>? ProviderGetPlayerCurrentNameWorld;
-    
+
+    /// <summary>
+    /// GetPlayerLodestoneId.
+    /// </summary>
+    public readonly ICallGateProvider<string, uint, uint>? ProviderGetPlayerLodestoneId;
+
     /// <summary>
     /// GetPlayerNotes.
     /// </summary>
     public readonly ICallGateProvider<string, uint, string>? ProviderGetPlayerNotes;
+
+    /// <summary>
+    /// GetPlayerPreviousNames.
+    /// </summary>
+    public readonly ICallGateProvider<string, uint, string[]>? ProviderGetPlayerPreviousNames;
+
+    /// <summary>
+    /// GetPlayerPreviousWorlds.
+    /// </summary>
+    public readonly ICallGateProvider<string, uint, string[]>? ProviderGetPlayerPreviousWorlds;
+
+    /// <summary>
+    /// GetPlayersPreviousNamesWorlds.
+    /// </summary>
+    public readonly ICallGateProvider<(string, uint)[], ((string, uint), string[], uint[])[]>? ProviderGetPlayersPreviousNamesWorlds;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PlayerTrackProvider"/> class.
@@ -77,7 +116,18 @@ public class PlayerTrackProvider
         {
             DalamudContext.PluginLog.Error($"Error registering IPC provider for {LabelProviderGetPlayerCurrentNameWorld}:\n{e}");
         }
-        
+
+        try 
+        {
+            this.ProviderGetPlayerLodestoneId =
+                pluginInterface.GetIpcProvider<string, uint, uint>(LabelProviderGetPlayerLodestoneId);
+            this.ProviderGetPlayerLodestoneId.RegisterFunc(api.GetPlayerLodestoneId);
+        }
+        catch (Exception e) 
+        {
+            DalamudContext.PluginLog.Error($"Error registering IPC provider for {LabelProviderGetPlayerLodestoneId}:\n{e}");
+        }
+
         try
         {
             this.ProviderGetPlayerNotes =
@@ -87,6 +137,39 @@ public class PlayerTrackProvider
         catch (Exception e)
         {
             DalamudContext.PluginLog.Error($"Error registering IPC provider for {LabelProviderGetPlayerNotes}:\n{e}");
+        }
+
+        try 
+        {
+            this.ProviderGetPlayerPreviousNames =
+                pluginInterface.GetIpcProvider<string, uint, string[]>(LabelProviderGetPlayerPreviousNames);
+            this.ProviderGetPlayerPreviousNames.RegisterFunc(api.GetPlayerPreviousNames);
+        }
+        catch (Exception e) 
+        {
+            DalamudContext.PluginLog.Error($"Error registering IPC provider for {LabelProviderGetPlayerPreviousNames}:\n{e}");
+        }
+
+        try 
+        {
+            this.ProviderGetPlayerPreviousWorlds =
+                pluginInterface.GetIpcProvider<string, uint, string[]>(LabelProviderGetPlayerPreviousWorlds);
+            this.ProviderGetPlayerPreviousWorlds.RegisterFunc(api.GetPlayerPreviousWorlds);
+        }
+        catch (Exception e) 
+        {
+            DalamudContext.PluginLog.Error($"Error registering IPC provider for {LabelProviderGetPlayerPreviousWorlds}:\n{e}");
+        }
+
+        try
+        {
+            this.ProviderGetPlayersPreviousNamesWorlds =
+                pluginInterface.GetIpcProvider<(string, uint)[], ((string, uint), string[], uint[])[]>(LabelProviderGetPlayersPreviousNamesWorlds);
+            this.ProviderGetPlayersPreviousNamesWorlds.RegisterFunc(api.GetPlayersPreviousNamesWorlds);
+        }
+        catch (Exception e)
+        {
+            DalamudContext.PluginLog.Error($"Error registering IPC provider for {LabelProviderGetPlayersPreviousNamesWorlds}:\n{e}");
         }
     }
 
@@ -99,5 +182,8 @@ public class PlayerTrackProvider
         this.ProviderAPIVersion?.UnregisterFunc();
         this.ProviderGetPlayerCurrentNameWorld?.UnregisterFunc();
         this.ProviderGetPlayerNotes?.UnregisterFunc();
+        this.ProviderGetPlayerPreviousNames?.UnregisterFunc();
+        this.ProviderGetPlayerPreviousWorlds?.UnregisterFunc();
+        this.ProviderGetPlayersPreviousNamesWorlds?.UnregisterFunc();
     }
 }

--- a/PlayerTrack.Plugin/API/PlayerTrackProvider.cs
+++ b/PlayerTrack.Plugin/API/PlayerTrackProvider.cs
@@ -28,9 +28,9 @@ public class PlayerTrackProvider
     public const string LabelProviderGetPlayerNotes = "PlayerTrack.GetPlayerNotes";
 
     /// <summary>
-    /// GetUniquePlayerNameWorldHistories.
+    /// GetPlayerNameWorldHistories.
     /// </summary>
-    public const string LabelProviderGetUniquePlayerNameWorldHistories = "PlayerTrack.GetUniquePlayerNameWorldHistories";
+    public const string LabelProviderGetPlayerNameWorldHistories = "PlayerTrack.GetPlayerNameWorldHistories";
 
     /// <summary>
     /// API.
@@ -55,7 +55,7 @@ public class PlayerTrackProvider
     /// <summary>
     /// GetUniquePlayerNameWorldHistories.
     /// </summary>
-    public readonly ICallGateProvider<(string, uint)[], ((string, uint), (string, uint)[])[]>? GetUniquePlayerNameWorldHistories;
+    public readonly ICallGateProvider<(string, uint)[], ((string, uint), (string, uint)[])[]>? GetPlayerNameWorldHistories;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PlayerTrackProvider"/> class.
@@ -101,13 +101,13 @@ public class PlayerTrackProvider
 
         try
         {
-            this.GetUniquePlayerNameWorldHistories =
-                pluginInterface.GetIpcProvider<(string, uint)[], ((string, uint), (string, uint)[])[]>(LabelProviderGetUniquePlayerNameWorldHistories);
-            this.GetUniquePlayerNameWorldHistories.RegisterFunc(api.GetUniquePlayerNameWorldHistories);
+            this.GetPlayerNameWorldHistories =
+                pluginInterface.GetIpcProvider<(string, uint)[], ((string, uint), (string, uint)[])[]>(LabelProviderGetPlayerNameWorldHistories);
+            this.GetPlayerNameWorldHistories.RegisterFunc(api.GetPlayerNameWorldHistories);
         }
         catch (Exception e)
         {
-            DalamudContext.PluginLog.Error($"Error registering IPC provider for {LabelProviderGetUniquePlayerNameWorldHistories}:\n{e}");
+            DalamudContext.PluginLog.Error($"Error registering IPC provider for {LabelProviderGetPlayerNameWorldHistories}:\n{e}");
         }
     }
 
@@ -120,6 +120,6 @@ public class PlayerTrackProvider
         this.ProviderAPIVersion?.UnregisterFunc();
         this.ProviderGetPlayerCurrentNameWorld?.UnregisterFunc();
         this.ProviderGetPlayerNotes?.UnregisterFunc();
-        this.GetUniquePlayerNameWorldHistories?.UnregisterFunc();
+        this.GetPlayerNameWorldHistories?.UnregisterFunc();
     }
 }

--- a/PlayerTrack.sln
+++ b/PlayerTrack.sln
@@ -1,56 +1,54 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PlayerTrack.Plugin", "PlayerTrack.Plugin\PlayerTrack.Plugin.csproj", "{92380CDF-883F-4E69-BDFD-C33208F4876A}"
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34322.80
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PlayerTrack.Plugin", "PlayerTrack.Plugin\PlayerTrack.Plugin.csproj", "{92380CDF-883F-4E69-BDFD-C33208F4876A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PlayerTrack.Models", "PlayerTrack.Models\PlayerTrack.Models.csproj", "{22E697FA-1E69-4816-A162-924D19CA5A62}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PlayerTrack.Models", "PlayerTrack.Models\PlayerTrack.Models.csproj", "{22E697FA-1E69-4816-A162-924D19CA5A62}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PlayerTrack.Domain", "PlayerTrack.Domain\PlayerTrack.Domain.csproj", "{7B3F1690-0D71-4F5A-B0C6-9001B94FD16A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PlayerTrack.Domain", "PlayerTrack.Domain\PlayerTrack.Domain.csproj", "{7B3F1690-0D71-4F5A-B0C6-9001B94FD16A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PlayerTrack.UserInterface", "PlayerTrack.UserInterface\PlayerTrack.UserInterface.csproj", "{D72E03DD-252C-41FA-B177-1E76A3FE306F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PlayerTrack.UserInterface", "PlayerTrack.UserInterface\PlayerTrack.UserInterface.csproj", "{D72E03DD-252C-41FA-B177-1E76A3FE306F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PlayerTrack.Infrastructure", "PlayerTrack.Infrastructure\PlayerTrack.Infrastructure.csproj", "{CBD90FC9-C832-4D91-A309-DF50F3E66B08}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PlayerTrack.Infrastructure", "PlayerTrack.Infrastructure\PlayerTrack.Infrastructure.csproj", "{CBD90FC9-C832-4D91-A309-DF50F3E66B08}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{FDE1DB46-52C4-413B-9675-0601B8100BD0}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Release|Any CPU = Release|Any CPU
 		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{92380CDF-883F-4E69-BDFD-C33208F4876A}.Release|Any CPU.ActiveCfg = Release|x64
-		{92380CDF-883F-4E69-BDFD-C33208F4876A}.Release|Any CPU.Build.0 = Release|x64
 		{92380CDF-883F-4E69-BDFD-C33208F4876A}.Debug|Any CPU.ActiveCfg = Debug|x64
 		{92380CDF-883F-4E69-BDFD-C33208F4876A}.Debug|Any CPU.Build.0 = Debug|x64
-		{69D0736E-391C-4A90-B9B6-5B5F6CC8858F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{69D0736E-391C-4A90-B9B6-5B5F6CC8858F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{69D0736E-391C-4A90-B9B6-5B5F6CC8858F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{69D0736E-391C-4A90-B9B6-5B5F6CC8858F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{62794DA0-3C4D-45A4-A31E-4A8569CA2B65}.Release|Any CPU.ActiveCfg = Release|x64
-		{62794DA0-3C4D-45A4-A31E-4A8569CA2B65}.Release|Any CPU.Build.0 = Release|x64
-		{62794DA0-3C4D-45A4-A31E-4A8569CA2B65}.Debug|Any CPU.ActiveCfg = Debug|x64
-		{62794DA0-3C4D-45A4-A31E-4A8569CA2B65}.Debug|Any CPU.Build.0 = Debug|x64
-		{22E697FA-1E69-4816-A162-924D19CA5A62}.Release|Any CPU.ActiveCfg = Release|x64
-		{22E697FA-1E69-4816-A162-924D19CA5A62}.Release|Any CPU.Build.0 = Release|x64
+		{92380CDF-883F-4E69-BDFD-C33208F4876A}.Release|Any CPU.ActiveCfg = Release|x64
+		{92380CDF-883F-4E69-BDFD-C33208F4876A}.Release|Any CPU.Build.0 = Release|x64
 		{22E697FA-1E69-4816-A162-924D19CA5A62}.Debug|Any CPU.ActiveCfg = Debug|x64
 		{22E697FA-1E69-4816-A162-924D19CA5A62}.Debug|Any CPU.Build.0 = Debug|x64
-		{7B3F1690-0D71-4F5A-B0C6-9001B94FD16A}.Release|Any CPU.ActiveCfg = Release|x64
-		{7B3F1690-0D71-4F5A-B0C6-9001B94FD16A}.Release|Any CPU.Build.0 = Release|x64
+		{22E697FA-1E69-4816-A162-924D19CA5A62}.Release|Any CPU.ActiveCfg = Release|x64
+		{22E697FA-1E69-4816-A162-924D19CA5A62}.Release|Any CPU.Build.0 = Release|x64
 		{7B3F1690-0D71-4F5A-B0C6-9001B94FD16A}.Debug|Any CPU.ActiveCfg = Debug|x64
 		{7B3F1690-0D71-4F5A-B0C6-9001B94FD16A}.Debug|Any CPU.Build.0 = Debug|x64
-		{D72E03DD-252C-41FA-B177-1E76A3FE306F}.Release|Any CPU.ActiveCfg = Release|x64
-		{D72E03DD-252C-41FA-B177-1E76A3FE306F}.Release|Any CPU.Build.0 = Release|x64
+		{7B3F1690-0D71-4F5A-B0C6-9001B94FD16A}.Release|Any CPU.ActiveCfg = Release|x64
+		{7B3F1690-0D71-4F5A-B0C6-9001B94FD16A}.Release|Any CPU.Build.0 = Release|x64
 		{D72E03DD-252C-41FA-B177-1E76A3FE306F}.Debug|Any CPU.ActiveCfg = Debug|x64
 		{D72E03DD-252C-41FA-B177-1E76A3FE306F}.Debug|Any CPU.Build.0 = Debug|x64
-		{CBD90FC9-C832-4D91-A309-DF50F3E66B08}.Release|Any CPU.ActiveCfg = Release|x64
-		{CBD90FC9-C832-4D91-A309-DF50F3E66B08}.Release|Any CPU.Build.0 = Release|x64
+		{D72E03DD-252C-41FA-B177-1E76A3FE306F}.Release|Any CPU.ActiveCfg = Release|x64
+		{D72E03DD-252C-41FA-B177-1E76A3FE306F}.Release|Any CPU.Build.0 = Release|x64
 		{CBD90FC9-C832-4D91-A309-DF50F3E66B08}.Debug|Any CPU.ActiveCfg = Debug|x64
 		{CBD90FC9-C832-4D91-A309-DF50F3E66B08}.Debug|Any CPU.Build.0 = Debug|x64
-		{B266AE31-41EA-417B-8091-901E7096A0D9}.Release|Any CPU.ActiveCfg = Release|x64
-		{B266AE31-41EA-417B-8091-901E7096A0D9}.Release|Any CPU.Build.0 = Release|x64
-		{B266AE31-41EA-417B-8091-901E7096A0D9}.Debug|Any CPU.ActiveCfg = Debug|x64
-		{B266AE31-41EA-417B-8091-901E7096A0D9}.Debug|Any CPU.Build.0 = Debug|x64
-		{529C5026-4E2A-4684-B220-39EE1E3E5C5E}.Release|Any CPU.ActiveCfg = Release|x64
-		{529C5026-4E2A-4684-B220-39EE1E3E5C5E}.Release|Any CPU.Build.0 = Release|x64
-		{529C5026-4E2A-4684-B220-39EE1E3E5C5E}.Debug|Any CPU.ActiveCfg = Debug|x64
-		{529C5026-4E2A-4684-B220-39EE1E3E5C5E}.Debug|Any CPU.Build.0 = Debug|x64
+		{CBD90FC9-C832-4D91-A309-DF50F3E66B08}.Release|Any CPU.ActiveCfg = Release|x64
+		{CBD90FC9-C832-4D91-A309-DF50F3E66B08}.Release|Any CPU.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {5AF89DCB-EBA6-47EF-BBE7-81469DF4F04D}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Adds a new IPC function `GetUniquePlayerNameWorldHistories()` for retrieving the player name/world history for a list of players. 

The reason is I want to use this information as an optional feature for my plugin [PvP Tracker](https://github.com/wrath16/PvpStats) to persist stats across name/world changes. My plugin is quite recent so I opted to only transmit records that are not migrated where we can be sure of the name+world combo. I've tested the function and verified it works as intended.