### PR TITLE
Refactor IPC method GetPlayerNameWorldHistories([..]) to GetAllPlayerNameWorldHistories()

### DIFF
--- a/PlayerTrack.Domain/Services/PlayerServices/PlayerChangeService.cs
+++ b/PlayerTrack.Domain/Services/PlayerServices/PlayerChangeService.cs
@@ -69,10 +69,10 @@ public class PlayerChangeService
         return worldNames.Any() ? string.Join(", ", worldNames) : string.Empty;
     }
 
-    public static List<PlayerNameWorldHistory> GetPlayerNameWorldHistories(IEnumerable<int> playerIds)
+    public static List<PlayerNameWorldHistory> GetAllPlayerNameWorldHistories()
     {
-        DalamudContext.PluginLog.Verbose($"Entering PlayerChangeService.GetPlayerNameWorldHistories()");
-        var nameWorldHistories = RepositoryContext.PlayerNameWorldHistoryRepository.GetPlayerNameWorldHistories(playerIds.ToArray());
+        DalamudContext.PluginLog.Verbose($"Entering PlayerChangeService.GetAllPlayerNameWorldHistories()");
+        var nameWorldHistories = RepositoryContext.PlayerNameWorldHistoryRepository.GetAllPlayerNameWorldHistories();
         if (nameWorldHistories == null)
         {
             return new List<PlayerNameWorldHistory>();

--- a/PlayerTrack.Infrastructure/Repositories/PlayerNameWorldHistoryRepository.cs
+++ b/PlayerTrack.Infrastructure/Repositories/PlayerNameWorldHistoryRepository.cs
@@ -123,6 +123,17 @@ public class PlayerNameWorldHistoryRepository : BaseRepository
         }
     }
 
+    public IEnumerable<PlayerNameWorldHistory>? GetAllPlayerNameWorldHistories() {
+        DalamudContext.PluginLog.Verbose($"Entering PlayerNameWorldHistoryRepository.GetPlayerNameWorldHistories()");
+        try {
+            return this.Connection.Query<PlayerNameWorldHistoryDTO>("SELECT * from player_name_world_histories").Select(x => Mapper.Map<PlayerNameWorldHistory>(x));
+        }
+        catch (Exception ex) {
+            DalamudContext.PluginLog.Error(ex, $"Failed to get bulk player name world history.");
+            return null;
+        }
+    }
+
     public bool DeleteNameWorldHistory(int playerId)
     {
         DalamudContext.PluginLog.Verbose($"Entering PlayerNameWorldHistoryRepository.DeleteNameWorldHistory(): {playerId}");

--- a/PlayerTrack.Infrastructure/Repositories/PlayerNameWorldHistoryRepository.cs
+++ b/PlayerTrack.Infrastructure/Repositories/PlayerNameWorldHistoryRepository.cs
@@ -118,7 +118,7 @@ public class PlayerNameWorldHistoryRepository : BaseRepository
         }
         catch (Exception ex) 
         {
-            DalamudContext.PluginLog.Error(ex, $"Failed to get bulk player name world history.");
+            DalamudContext.PluginLog.Error(ex, $"Failed to get bulk player name world history");
             return null;
         }
     }
@@ -126,10 +126,11 @@ public class PlayerNameWorldHistoryRepository : BaseRepository
     public IEnumerable<PlayerNameWorldHistory>? GetAllPlayerNameWorldHistories() {
         DalamudContext.PluginLog.Verbose($"Entering PlayerNameWorldHistoryRepository.GetPlayerNameWorldHistories()");
         try {
-            return this.Connection.Query<PlayerNameWorldHistoryDTO>("SELECT * from player_name_world_histories").Select(x => Mapper.Map<PlayerNameWorldHistory>(x));
+            const string sql = "SELECT * from player_name_world_histories";
+            return this.Connection.Query<PlayerNameWorldHistoryDTO>(sql).Select(x => Mapper.Map<PlayerNameWorldHistory>(x));
         }
         catch (Exception ex) {
-            DalamudContext.PluginLog.Error(ex, $"Failed to get bulk player name world history.");
+            DalamudContext.PluginLog.Error(ex, $"Failed to get all player name world histories");
             return null;
         }
     }

--- a/PlayerTrack.Plugin/API/IPlayerTrackAPI.cs
+++ b/PlayerTrack.Plugin/API/IPlayerTrackAPI.cs
@@ -30,6 +30,6 @@ public interface IPlayerTrackAPI
     /// <summary>
     /// Retrieves all player names/world history records.
     /// </summary>
-    /// <returns>tuple array of current (player name, world id) and an array of (player name, world id) name/world changes.</returns>
+    /// <returns>tuple array of current (player name, world id) and an array of all previous (player name, world id) combos.</returns>
     public ((string, uint), (string, uint)[])[] GetAllPlayerNameWorldHistories();
 }

--- a/PlayerTrack.Plugin/API/IPlayerTrackAPI.cs
+++ b/PlayerTrack.Plugin/API/IPlayerTrackAPI.cs
@@ -28,9 +28,8 @@ public interface IPlayerTrackAPI
     public string GetPlayerNotes(string name, uint worldId);
 
     /// <summary>
-    /// Returns the player names/world history for a list of players
+    /// Retrieves all player names/world history records.
     /// </summary>
-    /// <param name="players">tuple array of (player name, world id)</param>
     /// <returns>tuple array of current (player name, world id) and an array of (player name, world id) name/world changes.</returns>
-    public ((string, uint), (string, uint)[])[] GetPlayerNameWorldHistories((string, uint)[] players);
+    public ((string, uint), (string, uint)[])[] GetAllPlayerNameWorldHistories();
 }

--- a/PlayerTrack.Plugin/API/PlayerTrackProvider.cs
+++ b/PlayerTrack.Plugin/API/PlayerTrackProvider.cs
@@ -29,9 +29,9 @@ public class PlayerTrackProvider
     public const string LabelProviderGetPlayerNotes = "PlayerTrack.GetPlayerNotes";
 
     /// <summary>
-    /// GetPlayerNameWorldHistories.
+    /// GetAllPlayerNameWorldHistories.
     /// </summary>
-    public const string LabelProviderGetPlayerNameWorldHistories = "PlayerTrack.GetPlayerNameWorldHistories";
+    public const string LabelProviderGetAllPlayerNameWorldHistories = "PlayerTrack.GetAllPlayerNameWorldHistories";
 
     /// <summary>
     /// API.
@@ -54,9 +54,9 @@ public class PlayerTrackProvider
     public readonly ICallGateProvider<string, uint, string>? ProviderGetPlayerNotes;
 
     /// <summary>
-    /// GetUniquePlayerNameWorldHistories.
+    /// ProviderGetAllPlayerNameWorldHistories.
     /// </summary>
-    public readonly ICallGateProvider<(string, uint)[], ((string, uint), (string, uint)[])[]>? GetPlayerNameWorldHistories;
+    public readonly ICallGateProvider<((string, uint), (string, uint)[])[]>? ProviderGetAllPlayerNameWorldHistories;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PlayerTrackProvider"/> class.
@@ -102,13 +102,13 @@ public class PlayerTrackProvider
 
         try
         {
-            this.GetPlayerNameWorldHistories =
-                pluginInterface.GetIpcProvider<(string, uint)[], ((string, uint), (string, uint)[])[]>(LabelProviderGetPlayerNameWorldHistories);
-            this.GetPlayerNameWorldHistories.RegisterFunc(api.GetPlayerNameWorldHistories);
+            this.ProviderGetAllPlayerNameWorldHistories =
+                pluginInterface.GetIpcProvider<((string, uint), (string, uint)[])[]>(LabelProviderGetAllPlayerNameWorldHistories);
+            this.ProviderGetAllPlayerNameWorldHistories.RegisterFunc(api.GetAllPlayerNameWorldHistories);
         }
         catch (Exception e)
         {
-            DalamudContext.PluginLog.Error($"Error registering IPC provider for {LabelProviderGetPlayerNameWorldHistories}:\n{e}");
+            DalamudContext.PluginLog.Error($"Error registering IPC provider for {LabelProviderGetAllPlayerNameWorldHistories}:\n{e}");
         }
     }
 
@@ -121,6 +121,6 @@ public class PlayerTrackProvider
         this.ProviderAPIVersion?.UnregisterFunc();
         this.ProviderGetPlayerCurrentNameWorld?.UnregisterFunc();
         this.ProviderGetPlayerNotes?.UnregisterFunc();
-        this.GetPlayerNameWorldHistories?.UnregisterFunc();
+        this.ProviderGetAllPlayerNameWorldHistories?.UnregisterFunc();
     }
 }


### PR DESCRIPTION
Reworked the IPC method GetPlayerNameWorldHistories([..]) to GetAllPlayerNameWorldHistories().

All identity change records are now retrieved and transmitted instead of only those from a provided list. This massively improves performance since we no longer have to pre-filter against the player list to retrieve IDs.

Don't think anyone else uses the function besides myself, so I've opted to replace instead of add.