### PR TITLE
fix: issue when drawing player merge tab in data section of settings.

### DIFF
--- a/PlayerTrack.UserInterface/Config/Components/DataComponent.cs
+++ b/PlayerTrack.UserInterface/Config/Components/DataComponent.cs
@@ -157,7 +157,7 @@ public class DataComponent : ConfigViewComponent
         DrawPlayer(ref updatePlayer, updatePlayerComboBox, "SelectPlayerToUpdate");
     }
     
-    private void DrawPlayer(ref Player? selectedPlayer, FilterComboBox comboBox, string label)
+    private void DrawPlayer(ref Player? selectedPlayer, FilterComboBox? comboBox, string? label)
     {
         var isPlayerSelected = selectedPlayer != null;
         var buttonLabel = DalamudContext.LocManager.GetString("OpenPlayer");
@@ -170,7 +170,7 @@ public class DataComponent : ConfigViewComponent
         ImGui.EndDisabled();
 
         ImGui.SameLine();
-        var selectedIndex = comboBox.Draw(label, 300f);
+        var selectedIndex = comboBox?.Draw(label ?? "null", 300f);
         if (selectedIndex.HasValue)
         {
             selectedPlayer = players[selectedIndex.Value];


### PR DESCRIPTION
I found that when you have an empty database, and you open the settings to Data -> Merge there is an error thrown in the console on mass. This is because of either the variable `comboBox` being `null` or the variable `label` being `null`. So I added a safety check for both. However, I would like to note, despite neither of those to variables being reassigned there is no null annotation on the variables, and I am unsure as how it was thrown on line 173 and not upon the call of this method.

While fixing my database, I noticed this issue with a newly created database.