### PR TITLE
fix: Workaround for compiler warning CS4014

### DIFF
--- a/PlayerTrack.Plugin/Plugin/ContextMenuHandler.cs
+++ b/PlayerTrack.Plugin/Plugin/ContextMenuHandler.cs
@@ -63,7 +63,7 @@ public static class ContextMenuHandler
     {
         var selectedPlayer = menuItemClickedArgs.GetPlayer();
         if (selectedPlayer == null) return;
-        _ = ServiceContext.LodestoneService.OpenLodestoneProfile(selectedPlayer.Name, selectedPlayer.HomeWorld);
+        ServiceContext.LodestoneService.OpenLodestoneProfile(selectedPlayer.Name, selectedPlayer.HomeWorld);
     }
 
     public static void Restart()


### PR DESCRIPTION
Since `DalamudContext.DataManager.GetWorldNameById(uint)` and `ServiceContext.PlayerDataService.GetPlayer(string, uint)` must be called by the main thread as per Dalamud we move the actual async operation inside the `OpenLodestoneProfile(string, uint)` method after the two methods requiring to be called on the main thread have processed.

I noticed this compiler warning while making the other two fixes, this one is probably safe to ignore, but if you want it you can merge it :3